### PR TITLE
Updating Systemd services to be more reliable

### DIFF
--- a/at_telnet_daemon/at-telnet/systemd_units/at-telnet-daemon.service
+++ b/at_telnet_daemon/at-telnet/systemd_units/at-telnet-daemon.service
@@ -1,14 +1,21 @@
 [Unit]
 Description=Telnet daemon for AT command
+
+# Being extra silly with the dependencies for this.
+# TODO: Update the python code to validate that the serial port
+# is working on a regular basis, and keep attempting to retry
+# if not. Then these dependencies won't need to be so strict.
 After=socat-smd11.service
-PartOf=socat-smd11.service
-Requires=socat-smd11-from-ttyIN.service
-Requires=socat-smd11-to-ttyIN.service
+After=socat-smd11-from-ttyIN.service
+After=socat-smd11-to-ttyIN.service
+BindsTo=socat-smd11.service
+BindsTo=socat-smd11-from-ttyIN.service
+BindsTo=socat-smd11-to-ttyIN.service
 
 [Service]
 ExecStart=/usrdata/at-telnet/modem-multiclient.py
 Restart=always
-RestartSec=1
+RestartSec=1s
 
 [Install]
 WantedBy=multi-user.target

--- a/at_telnet_daemon/at-telnet/systemd_units/at-telnet-daemon.service
+++ b/at_telnet_daemon/at-telnet/systemd_units/at-telnet-daemon.service
@@ -6,16 +6,19 @@ Description=Telnet daemon for AT command
 # is working on a regular basis, and keep attempting to retry
 # if not. Then these dependencies won't need to be so strict.
 After=socat-smd11.service
-After=socat-smd11-from-ttyIN.service
-After=socat-smd11-to-ttyIN.service
-BindsTo=socat-smd11.service
-BindsTo=socat-smd11-from-ttyIN.service
-BindsTo=socat-smd11-to-ttyIN.service
+Requires=socat-smd11.service socat-smd11-from-ttyIN.service socat-smd11-to-ttyIN.service
+ReloadPropagatedFrom=socat-smd11.service socat-smd11-from-ttyIN.service socat-smd11-to-ttyIN.service
+
+StartLimitIntervalSec=2m
+StartLimitBurst=100
 
 [Service]
 ExecStart=/usrdata/at-telnet/modem-multiclient.py
 Restart=always
-RestartSec=1s
+RestartSec=2s
+# Increased log rate limits, so we can see what's going on.
+LogRateLimitIntervalSec=5s
+LogRateLimitBurst=100
 
 [Install]
 WantedBy=multi-user.target

--- a/at_telnet_daemon/at-telnet/systemd_units/socat-smd11-from-ttyIN.service
+++ b/at_telnet_daemon/at-telnet/systemd_units/socat-smd11-from-ttyIN.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Read from /dev/ttyIN and write to smd11
-Requires=socat-smd11.service
+BindsTo=socat-smd11.service
 After=socat-smd11.service
 
 [Service]

--- a/at_telnet_daemon/at-telnet/systemd_units/socat-smd11-from-ttyIN.service
+++ b/at_telnet_daemon/at-telnet/systemd_units/socat-smd11-from-ttyIN.service
@@ -5,8 +5,6 @@ After=socat-smd11.service
 
 [Service]
 ExecStart=/bin/bash -c "/bin/cat /dev/ttyIN > /dev/smd11"
-# Add a delay to prevent the clients from starting too early
-ExecStartPre=/bin/sleep 2
 Restart=always
 RestartSec=1s
 StandardInput=tty-force

--- a/at_telnet_daemon/at-telnet/systemd_units/socat-smd11-from-ttyIN.service
+++ b/at_telnet_daemon/at-telnet/systemd_units/socat-smd11-from-ttyIN.service
@@ -5,10 +5,10 @@ After=socat-smd11.service
 
 [Service]
 ExecStart=/bin/bash -c "/bin/cat /dev/ttyIN > /dev/smd11"
+ExecStartPost=/bin/sleep 2s
+StandardInput=tty-force
 Restart=always
 RestartSec=1s
-StandardInput=tty-force
-StandardOutput=tty-force
 
 [Install]
 WantedBy=multi-user.target

--- a/at_telnet_daemon/at-telnet/systemd_units/socat-smd11-from-ttyIN.service
+++ b/at_telnet_daemon/at-telnet/systemd_units/socat-smd11-from-ttyIN.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Read from /dev/ttyIN and write to smd11
 Requires=socat-smd11.service
+After=socat-smd11.service
 
 [Service]
 ExecStart=/bin/bash -c "/bin/cat /dev/ttyIN > /dev/smd11"

--- a/at_telnet_daemon/at-telnet/systemd_units/socat-smd11-from-ttyIN.service
+++ b/at_telnet_daemon/at-telnet/systemd_units/socat-smd11-from-ttyIN.service
@@ -1,12 +1,13 @@
 [Unit]
 Description=Read from /dev/ttyIN and write to smd11
-After=socat-smd11.service
-PartOf=socat-smd11.service
+Requires=socat-smd11.service
 
 [Service]
 ExecStart=/bin/bash -c "/bin/cat /dev/ttyIN > /dev/smd11"
+# Add a delay to prevent the clients from starting too early
+ExecStartPre=/bin/sleep 2
 Restart=always
-RestartSec=1
+RestartSec=1s
 StandardInput=tty-force
 StandardOutput=tty-force
 

--- a/at_telnet_daemon/at-telnet/systemd_units/socat-smd11-to-ttyIN.service
+++ b/at_telnet_daemon/at-telnet/systemd_units/socat-smd11-to-ttyIN.service
@@ -5,10 +5,10 @@ After=socat-smd11.service
 
 [Service]
 ExecStart=/bin/bash -c "/bin/cat /dev/smd11 > /dev/ttyIN"
+ExecStartPost=/bin/sleep 2s
+StandardInput=tty-force
 Restart=always
 RestartSec=1s
-StandardInput=tty-force
-StandardOutput=tty-force
 
 [Install]
 WantedBy=multi-user.target

--- a/at_telnet_daemon/at-telnet/systemd_units/socat-smd11-to-ttyIN.service
+++ b/at_telnet_daemon/at-telnet/systemd_units/socat-smd11-to-ttyIN.service
@@ -1,12 +1,13 @@
 [Unit]
 Description=Read from /dev/smd11 and write to ttyIN
-After=socat-smd11.service
-PartOf=socat-smd11.service
+Requires=socat-smd11.service
 
 [Service]
 ExecStart=/bin/bash -c "/bin/cat /dev/smd11 > /dev/ttyIN"
+# Add a delay to prevent the clients from starting too early
+ExecStartPre=/bin/sleep 2
 Restart=always
-RestartSec=1
+RestartSec=1s
 StandardInput=tty-force
 StandardOutput=tty-force
 

--- a/at_telnet_daemon/at-telnet/systemd_units/socat-smd11-to-ttyIN.service
+++ b/at_telnet_daemon/at-telnet/systemd_units/socat-smd11-to-ttyIN.service
@@ -5,8 +5,6 @@ After=socat-smd11.service
 
 [Service]
 ExecStart=/bin/bash -c "/bin/cat /dev/smd11 > /dev/ttyIN"
-# Add a delay to prevent the clients from starting too early
-ExecStartPre=/bin/sleep 2
 Restart=always
 RestartSec=1s
 StandardInput=tty-force

--- a/at_telnet_daemon/at-telnet/systemd_units/socat-smd11-to-ttyIN.service
+++ b/at_telnet_daemon/at-telnet/systemd_units/socat-smd11-to-ttyIN.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Read from /dev/smd11 and write to ttyIN
-Requires=socat-smd11.service
+BindsTo=socat-smd11.service
 After=socat-smd11.service
 
 [Service]

--- a/at_telnet_daemon/at-telnet/systemd_units/socat-smd11-to-ttyIN.service
+++ b/at_telnet_daemon/at-telnet/systemd_units/socat-smd11-to-ttyIN.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Read from /dev/smd11 and write to ttyIN
 Requires=socat-smd11.service
+After=socat-smd11.service
 
 [Service]
 ExecStart=/bin/bash -c "/bin/cat /dev/smd11 > /dev/ttyIN"

--- a/at_telnet_daemon/at-telnet/systemd_units/socat-smd11.service
+++ b/at_telnet_daemon/at-telnet/systemd_units/socat-smd11.service
@@ -4,10 +4,8 @@ After=ql-netd.service
 
 [Service]
 ExecStart=/usrdata/at-telnet/socat-armel-static -d -d pty,link=/dev/ttyIN,raw,echo=0 pty,link=/dev/ttyOUT,raw,echo=1
-# Add a delay to prevent the clients from starting too early
-ExecStartPost=/bin/sleep 2s
 Restart=always
-RestartSec=1
+RestartSec=1s
 
 [Install]
 WantedBy=multi-user.target

--- a/at_telnet_daemon/at-telnet/systemd_units/socat-smd11.service
+++ b/at_telnet_daemon/at-telnet/systemd_units/socat-smd11.service
@@ -4,6 +4,8 @@ After=ql-netd.service
 
 [Service]
 ExecStart=/usrdata/at-telnet/socat-armel-static -d -d pty,link=/dev/ttyIN,raw,echo=0 pty,link=/dev/ttyOUT,raw,echo=1
+# Add a delay to prevent the clients from starting too early
+ExecStartPost=/bin/sleep 2s
 Restart=always
 RestartSec=1s
 


### PR DESCRIPTION
Moving to using requires and after to make the ttyin and ttyout child services more reliable by ensuring the socat-smd11 service be up and running before they start. This also restarts the entire chain if any of the child processes are stopped for any reason. 

Moved the execstartpre to the child services rather the socat-smd11 parent to space out the turn up a little more.